### PR TITLE
Fix namespacing to use StudlyCaps, finally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,12 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "barnslig\\JMAP\\Tests\\": "tests"
+      "Barnslig\\Jmap\\Tests\\": "tests"
     }
   },
   "autoload": {
     "psr-4": {
-      "barnslig\\JMAP\\": "src"
+      "Barnslig\\Jmap\\": "src"
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -1426,36 +1426,31 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -1469,7 +1464,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -1478,7 +1473,21 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",
@@ -1910,16 +1919,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.52",
+            "version": "0.12.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc"
+                "reference": "45c7b999a4b7dd9ac5558bdaaf23dcebbef88223"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
-                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/45c7b999a4b7dd9ac5558bdaaf23dcebbef88223",
+                "reference": "45c7b999a4b7dd9ac5558bdaaf23dcebbef88223",
                 "shasum": ""
             },
             "require": {
@@ -1948,7 +1957,21 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-10-25T07:23:44+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-05T13:36:26+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2205,39 +2228,39 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.8",
+            "version": "8.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997"
+                "reference": "f5c8a5dd5e7e8d68d7562bfb48d47287d33937d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34c18baa6a44f1d1fbf0338907139e9dce95b997",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f5c8a5dd5e7e8d68d7562bfb48d47287d33937d6",
+                "reference": "f5c8a5dd5e7e8d68d7562bfb48d47287d33937d6",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2.0",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
+                "myclabs/deep-copy": "^1.10.0",
                 "phar-io/manifest": "^1.0.3",
                 "phar-io/version": "^2.0.1",
                 "php": "^7.2",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.7",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.10",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
                 "sebastian/comparator": "^3.0.2",
                 "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/exporter": "^3.1.1",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
                 "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^2.0.1",
@@ -2284,7 +2307,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-06-22T07:06:58+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-10T12:51:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Core/Capabilities/CoreCapability.php
+++ b/src/Core/Capabilities/CoreCapability.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\Capabilities;
+namespace Barnslig\Jmap\Core\Capabilities;
 
-use barnslig\JMAP\Core\Capability;
+use Barnslig\Jmap\Core\Capability;
 use Ds\Map;
 
 class CoreCapability extends Capability

--- a/src/Core/Capabilities/CoreCapability/CoreType/CoreEchoMethod.php
+++ b/src/Core/Capabilities/CoreCapability/CoreType/CoreEchoMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Capabilities\CoreCapability\CoreType;
+namespace Barnslig\Jmap\Core\Capabilities\CoreCapability\CoreType;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 class CoreEchoMethod implements Method
 {

--- a/src/Core/Capability.php
+++ b/src/Core/Capability.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Map;
 use JsonSerializable;

--- a/src/Core/CapabilityFactory.php
+++ b/src/Core/CapabilityFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use barnslig\JMAP\Core\Capability;
+use Barnslig\Jmap\Core\Capability;
 
 class CapabilityFactory implements FactoryInterface
 {

--- a/src/Core/Controllers/AbstractController.php
+++ b/src/Core/Controllers/AbstractController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\Controllers;
+namespace Barnslig\Jmap\Core\Controllers;
 
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\RequestContext;
 use Psr\Http\Server\RequestHandlerInterface;
 
 abstract class AbstractController implements RequestHandlerInterface

--- a/src/Core/Controllers/AbstractControllerFactory.php
+++ b/src/Core/Controllers/AbstractControllerFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Controllers;
+namespace Barnslig\Jmap\Core\Controllers;
 
-use barnslig\JMAP\Core\Capabilities\CoreCapability;
-use barnslig\JMAP\Core\Controllers\AbstractController;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Capabilities\CoreCapability;
+use Barnslig\Jmap\Core\Controllers\AbstractController;
+use Barnslig\Jmap\Core\RequestContext;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Core/Controllers/ApiController.php
+++ b/src/Core/Controllers/ApiController.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace barnslig\JMAP\Core\Controllers;
+namespace Barnslig\Jmap\Core\Controllers;
 
 use BadMethodCallException;
-use barnslig\JMAP\Core\Exceptions\MethodInvocationException;
-use barnslig\JMAP\Core\Exceptions\UnknownCapabilityException;
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Request;
-use barnslig\JMAP\Core\RequestErrors\LimitError;
-use barnslig\JMAP\Core\RequestErrors\NotJsonError;
-use barnslig\JMAP\Core\RequestErrors\NotRequestError;
-use barnslig\JMAP\Core\RequestErrors\UnknownCapabilityError;
-use barnslig\JMAP\Core\Response;
-use barnslig\JMAP\Core\Schemas\ValidationException;
+use Barnslig\Jmap\Core\Exceptions\MethodInvocationException;
+use Barnslig\Jmap\Core\Exceptions\UnknownCapabilityException;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Request;
+use Barnslig\Jmap\Core\RequestErrors\LimitError;
+use Barnslig\Jmap\Core\RequestErrors\NotJsonError;
+use Barnslig\Jmap\Core\RequestErrors\NotRequestError;
+use Barnslig\Jmap\Core\RequestErrors\UnknownCapabilityError;
+use Barnslig\Jmap\Core\Response;
+use Barnslig\Jmap\Core\Schemas\ValidationException;
 use Ds\Map;
 use Ds\Vector;
 use OutOfBoundsException;

--- a/src/Core/Controllers/SessionController.php
+++ b/src/Core/Controllers/SessionController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\Controllers;
+namespace Barnslig\Jmap\Core\Controllers;
 
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\Session;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Core/Exceptions/MethodInvocationException.php
+++ b/src/Core/Exceptions/MethodInvocationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Exceptions;
+namespace Barnslig\Jmap\Core\Exceptions;
 
 use RuntimeException;
 

--- a/src/Core/Exceptions/UnknownCapabilityException.php
+++ b/src/Core/Exceptions/UnknownCapabilityException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Exceptions;
+namespace Barnslig\Jmap\Core\Exceptions;
 
 use RuntimeException;
 

--- a/src/Core/Invocation.php
+++ b/src/Core/Invocation.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Map;
 use Ds\Vector;
-use barnslig\JMAP\Core\Exceptions\MethodInvocationException;
+use Barnslig\Jmap\Core\Exceptions\MethodInvocationException;
 use JsonSerializable;
 
 /**

--- a/src/Core/JsonPointer.php
+++ b/src/Core/JsonPointer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Vector;
 use InvalidArgumentException;

--- a/src/Core/Method.php
+++ b/src/Core/Method.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 /**
  * Interface to implement a JMAP method

--- a/src/Core/Methods/ChangesMethod.php
+++ b/src/Core/Methods/ChangesMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class ChangesMethod implements Method
 {

--- a/src/Core/Methods/CopyMethod.php
+++ b/src/Core/Methods/CopyMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class CopyMethod implements Method
 {

--- a/src/Core/Methods/GetMethod.php
+++ b/src/Core/Methods/GetMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class GetMethod implements Method
 {

--- a/src/Core/Methods/QueryChangesMethod.php
+++ b/src/Core/Methods/QueryChangesMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class QueryChangesMethod implements Method
 {

--- a/src/Core/Methods/QueryMethod.php
+++ b/src/Core/Methods/QueryMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class QueryMethod implements Method
 {

--- a/src/Core/Methods/SetMethod.php
+++ b/src/Core/Methods/SetMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core\Methods;
+namespace Barnslig\Jmap\Core\Methods;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 abstract class SetMethod implements Method
 {

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -6,7 +6,7 @@ Check out the PHPDocs!
 
 ## Usage
 
-The main entry point is an instance of the class `barnslig\JMAP\Core\JMAP`. It exposes multiple [PSR-15](https://www.php-fig.org/psr/psr-15/) compliant HTTP Server Request Handlers:
+The main entry point is an instance of the class `Barnslig\Jmap\Core\JMAP`. It exposes multiple [PSR-15](https://www.php-fig.org/psr/psr-15/) compliant HTTP Server Request Handlers:
 
 -   `JMAP::sessionHandler`
     -   Implements the [JMAP Session Resource](https://tools.ietf.org/html/rfc8620#section-2)

--- a/src/Core/Request.php
+++ b/src/Core/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Map;
 use Ds\Vector;

--- a/src/Core/RequestContext.php
+++ b/src/Core/RequestContext.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Session;
 
 /**
  * JMAP request context

--- a/src/Core/RequestContextFactory.php
+++ b/src/Core/RequestContextFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
-use barnslig\JMAP\Core\RequestContext;
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\RequestContext;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Session;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Core/RequestError.php
+++ b/src/Core/RequestError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use JsonSerializable;
 use Laminas\Diactoros\Response\JsonResponse;

--- a/src/Core/RequestErrors/LimitError.php
+++ b/src/Core/RequestErrors/LimitError.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\RequestErrors;
+namespace Barnslig\Jmap\Core\RequestErrors;
 
-use barnslig\JMAP\Core\RequestError;
+use Barnslig\Jmap\Core\RequestError;
 
 /**
  * Limit Error

--- a/src/Core/RequestErrors/NotJsonError.php
+++ b/src/Core/RequestErrors/NotJsonError.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\RequestErrors;
+namespace Barnslig\Jmap\Core\RequestErrors;
 
-use barnslig\JMAP\Core\RequestError;
+use Barnslig\Jmap\Core\RequestError;
 
 /**
  * Not JSON Error

--- a/src/Core/RequestErrors/NotRequestError.php
+++ b/src/Core/RequestErrors/NotRequestError.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace barnslig\JMAP\Core\RequestErrors;
+namespace Barnslig\Jmap\Core\RequestErrors;
 
-use barnslig\JMAP\Core\RequestError;
-use barnslig\JMAP\Core\Schemas\ValidationException;
+use Barnslig\Jmap\Core\RequestError;
+use Barnslig\Jmap\Core\Schemas\ValidationException;
 
 /**
  * Not Request Error

--- a/src/Core/RequestErrors/UnknownCapabilityError.php
+++ b/src/Core/RequestErrors/UnknownCapabilityError.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace barnslig\JMAP\Core\RequestErrors;
+namespace Barnslig\Jmap\Core\RequestErrors;
 
-use barnslig\JMAP\Core\RequestError;
-use barnslig\JMAP\Core\Exceptions\UnknownCapabilityException;
+use Barnslig\Jmap\Core\RequestError;
+use Barnslig\Jmap\Core\Exceptions\UnknownCapabilityException;
 
 /**
  * Unknown Capability Error

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Vector;
 use JsonSerializable;

--- a/src/Core/ResultReference.php
+++ b/src/Core/ResultReference.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
-use barnslig\JMAP\Core\Exceptions\MethodInvocationException;
+use Barnslig\Jmap\Core\Exceptions\MethodInvocationException;
 use Ds\Vector;
 
 /**

--- a/src/Core/Schemas/DirLoader.php
+++ b/src/Core/Schemas/DirLoader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Schemas;
+namespace Barnslig\Jmap\Core\Schemas;
 
 use Opis\JsonSchema\ISchemaLoader;
 use Opis\JsonSchema\Schema;

--- a/src/Core/Schemas/ValidationException.php
+++ b/src/Core/Schemas/ValidationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Schemas;
+namespace Barnslig\Jmap\Core\Schemas;
 
 /**
  * Exception that is raised when a schema validation fails

--- a/src/Core/Schemas/Validator.php
+++ b/src/Core/Schemas/Validator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Schemas;
+namespace Barnslig\Jmap\Core\Schemas;
 
 use Ds\Map;
 use Opis\JsonSchema\ISchemaLoader;

--- a/src/Core/Schemas/ValidatorFactory.php
+++ b/src/Core/Schemas/ValidatorFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core\Schemas;
+namespace Barnslig\Jmap\Core\Schemas;
 
-use barnslig\JMAP\Core\Schemas\Validator;
+use Barnslig\Jmap\Core\Schemas\Validator;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Opis\JsonSchema\Validator as OpisValidator;
 use OpisErrorPresenter\Implementation\MessageFormatterFactory;

--- a/src/Core/Schemas/ValidatorInterface.php
+++ b/src/Core/Schemas/ValidatorInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Core\Schemas;
+namespace Barnslig\Jmap\Core\Schemas;
 
 interface ValidatorInterface
 {

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
 use Ds\Map;
 use Ds\Vector;
-use barnslig\JMAP\Core\Exceptions\UnknownCapabilityException;
+use Barnslig\Jmap\Core\Exceptions\UnknownCapabilityException;
 use JsonSerializable;
 
 /**

--- a/src/Core/SessionFactory.php
+++ b/src/Core/SessionFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Core;
+namespace Barnslig\Jmap\Core;
 
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\Session;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Mail/MailCapability.php
+++ b/src/Mail/MailCapability.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Mail;
+namespace Barnslig\Jmap\Mail;
 
-use barnslig\JMAP\Core\Capability;
+use Barnslig\Jmap\Core\Capability;
 use Ds\Map;
 
 class MailCapability extends Capability

--- a/src/Mail/MailCapability/MailboxType/MailboxGetMethod.php
+++ b/src/Mail/MailCapability/MailboxType/MailboxGetMethod.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace barnslig\JMAP\Mail\MailCapability\MailboxType;
+namespace Barnslig\Jmap\Mail\MailCapability\MailboxType;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Methods\GetMethod;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Methods\GetMethod;
+use Barnslig\Jmap\Core\RequestContext;
 
 class MailboxGetMethod extends GetMethod
 {

--- a/src/Mail/MailInterface.php
+++ b/src/Mail/MailInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace barnslig\JMAP\Mail;
+namespace Barnslig\Jmap\Mail;
 
 interface MailInterface
 {

--- a/tests/Core/CapabilityTest.php
+++ b/tests/Core/CapabilityTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
 use Ds\Map;
-use barnslig\JMAP\Core\Capability;
+use Barnslig\Jmap\Core\Capability;
 use PHPUnit\Framework\TestCase;
 
 final class CapabilityTest extends TestCase

--- a/tests/Core/Controllers/ApiControllerTest.php
+++ b/tests/Core/Controllers/ApiControllerTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core\Controllers;
+namespace Barnslig\Jmap\Tests\Core\Controllers;
 
-use barnslig\JMAP\Core\Capabilities\CoreCapability;
-use barnslig\JMAP\Core\Capabilities\CoreCapability\CoreType\CoreEchoMethod;
-use barnslig\JMAP\Core\Controllers\ApiController;
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Request;
-use barnslig\JMAP\Core\RequestContext;
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
-use barnslig\JMAP\Core\Session;
-use barnslig\JMAP\Tests\Core\Stubs\FailingValidatorStub;
-use barnslig\JMAP\Tests\Core\Stubs\PassingValidatorStub;
-use barnslig\JMAP\Tests\Core\Stubs\RaisingMethodStub;
+use Barnslig\Jmap\Core\Capabilities\CoreCapability;
+use Barnslig\Jmap\Core\Capabilities\CoreCapability\CoreType\CoreEchoMethod;
+use Barnslig\Jmap\Core\Controllers\ApiController;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Request;
+use Barnslig\Jmap\Core\RequestContext;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Session;
+use Barnslig\Jmap\Tests\Core\Stubs\FailingValidatorStub;
+use Barnslig\Jmap\Tests\Core\Stubs\PassingValidatorStub;
+use Barnslig\Jmap\Tests\Core\Stubs\RaisingMethodStub;
 use Ds\Map;
 use Ds\Vector;
 use PHPUnit\Framework\TestCase;

--- a/tests/Core/Controllers/SessionControllerTest.php
+++ b/tests/Core/Controllers/SessionControllerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core\Controllers;
+namespace Barnslig\Jmap\Tests\Core\Controllers;
 
-use barnslig\JMAP\Core\Controllers\SessionController;
-use barnslig\JMAP\Core\RequestContext;
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
-use barnslig\JMAP\Core\Session;
-use barnslig\JMAP\Tests\Core\Stubs\PassingValidatorStub;
+use Barnslig\Jmap\Core\Controllers\SessionController;
+use Barnslig\Jmap\Core\RequestContext;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Session;
+use Barnslig\Jmap\Tests\Core\Stubs\PassingValidatorStub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/tests/Core/InvocationTest.php
+++ b/tests/Core/InvocationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
 use Ds\Vector;
 use Ds\Map;
-use barnslig\JMAP\Core\Invocation;
+use Barnslig\Jmap\Core\Invocation;
 use PHPUnit\Framework\TestCase;
 
 final class InvocationTest extends TestCase

--- a/tests/Core/JsonPointerTest.php
+++ b/tests/Core/JsonPointerTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
 use Ds\Vector;
-use barnslig\JMAP\Core\JsonPointer;
+use Barnslig\Jmap\Core\JsonPointer;
 use PHPUnit\Framework\TestCase;
 
 final class JsonPointerTest extends TestCase

--- a/tests/Core/RequestTest.php
+++ b/tests/Core/RequestTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Request;
-use barnslig\JMAP\Core\Schemas\ValidationException;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Request;
+use Barnslig\Jmap\Core\Schemas\ValidationException;
 use PHPUnit\Framework\TestCase;
 
 final class RequestTest extends TestCase

--- a/tests/Core/ResponseTest.php
+++ b/tests/Core/ResponseTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
 use Ds\Vector;
-use barnslig\JMAP\Core\Response;
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\Response;
+use Barnslig\Jmap\Core\Session;
 use PHPUnit\Framework\TestCase;
 
 final class ResponseTest extends TestCase

--- a/tests/Core/ResultReferenceTest.php
+++ b/tests/Core/ResultReferenceTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace JP\Tests\JMAP;
+namespace Barnslig\Jmap\Tests;
 
 use Ds\Vector;
-use barnslig\JMAP\Core\Exceptions\MethodInvocationException;
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\ResultReference;
+use Barnslig\Jmap\Core\Exceptions\MethodInvocationException;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\ResultReference;
 use PHPUnit\Framework\TestCase;
 
 final class ResultReferenceTest extends TestCase

--- a/tests/Core/SessionTest.php
+++ b/tests/Core/SessionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core;
+namespace Barnslig\Jmap\Tests\Core;
 
-use barnslig\JMAP\Core\Capabilities\CoreCapability\CoreType\CoreEchoMethod;
-use barnslig\JMAP\Core\Capability;
-use barnslig\JMAP\Core\Exceptions\UnknownCapabilityException;
-use barnslig\JMAP\Core\Session;
+use Barnslig\Jmap\Core\Capabilities\CoreCapability\CoreType\CoreEchoMethod;
+use Barnslig\Jmap\Core\Capability;
+use Barnslig\Jmap\Core\Exceptions\UnknownCapabilityException;
+use Barnslig\Jmap\Core\Session;
 use Ds\Map;
 use Ds\Vector;
 use PHPUnit\Framework\TestCase;

--- a/tests/Core/Stubs/FailingValidatorStub.php
+++ b/tests/Core/Stubs/FailingValidatorStub.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core\Stubs;
+namespace Barnslig\Jmap\Tests\Core\Stubs;
 
-use barnslig\JMAP\Core\Schemas\ValidationException;
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Schemas\ValidationException;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
 
 /**
  * A schema validator that is always failing

--- a/tests/Core/Stubs/PassingValidatorStub.php
+++ b/tests/Core/Stubs/PassingValidatorStub.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core\Stubs;
+namespace Barnslig\Jmap\Tests\Core\Stubs;
 
-use barnslig\JMAP\Core\Schemas\ValidatorInterface;
+use Barnslig\Jmap\Core\Schemas\ValidatorInterface;
 
 /**
  * A schema validator that is always passing

--- a/tests/Core/Stubs/RaisingMethodStub.php
+++ b/tests/Core/Stubs/RaisingMethodStub.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace barnslig\JMAP\Tests\Core\Stubs;
+namespace Barnslig\Jmap\Tests\Core\Stubs;
 
-use barnslig\JMAP\Core\Exceptions\MethodInvocationException;
-use barnslig\JMAP\Core\Invocation;
-use barnslig\JMAP\Core\Method;
-use barnslig\JMAP\Core\RequestContext;
+use Barnslig\Jmap\Core\Exceptions\MethodInvocationException;
+use Barnslig\Jmap\Core\Invocation;
+use Barnslig\Jmap\Core\Method;
+use Barnslig\Jmap\Core\RequestContext;
 
 /**
  * A JMAP method that is always raising a method invocation exception


### PR DESCRIPTION
[PSR-4](https://www.php-fig.org/psr/psr-4/#2-specification) does *not* specify how the vendor namespace should be formatted. However, most commonly used seems to be StudlyCaps, just as for class names. This MR finally uses StudlyCaps for namespace and fixes the tests namespace.

New namespaces:

* `Barnslig\Jmap\Core` - JMAP Core / Server Framework
* `Barnslig\Jmap\Tests\Core` - Unit tests of the core
* `Barnslig\Jmap\Mail` - JMAP Mail on top of the Core